### PR TITLE
Add recording reservation management and recording deletion

### DIFF
--- a/EPGPlayer/Localization/Localizable.xcstrings
+++ b/EPGPlayer/Localization/Localizable.xcstrings
@@ -522,6 +522,38 @@
         }
       }
     },
+    "Delete error" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除エラー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除错误"
+          }
+        }
+      }
+    },
+    "Delete recording" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除录像"
+          }
+        }
+      }
+    },
     "Don't add \"/api\" at the end of URL." : {
       "localizations" : {
         "ja" : {
@@ -1036,6 +1068,9 @@
           }
         }
       }
+    },
+    "More" : {
+
     },
     "Never" : {
       "localizations" : {

--- a/EPGPlayer/Localization/Localizable.xcstrings
+++ b/EPGPlayer/Localization/Localizable.xcstrings
@@ -410,6 +410,22 @@
         }
       }
     },
+    "Conflict" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "競合"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "冲突"
+          }
+        }
+      }
+    },
     "Continue" : {
       "localizations" : {
         "ja" : {
@@ -1117,6 +1133,22 @@
         }
       }
     },
+    "No reserves found" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予約が見つかりません"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到预约"
+          }
+        }
+      }
+    },
     "No schedule available" : {
       "localizations" : {
         "ja" : {
@@ -1212,6 +1244,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开测试页面"
+          }
+        }
+      }
+    },
+    "Overlap" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重叠"
           }
         }
       }
@@ -1441,6 +1489,22 @@
         }
       }
     },
+    "Reserves" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予約"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预约"
+          }
+        }
+      }
+    },
     "Reset" : {
       "localizations" : {
         "ja" : {
@@ -1473,6 +1537,22 @@
         }
       }
     },
+    "Rule" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルール"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "规则"
+          }
+        }
+      }
+    },
     "Search" : {
       "localizations" : {
         "ja" : {
@@ -1488,6 +1568,9 @@
           }
         }
       }
+    },
+    "Segment" : {
+
     },
     "Server Settings" : {
       "extractionState" : "manual",
@@ -1598,6 +1681,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示统计信息"
+          }
+        }
+      }
+    },
+    "Skip" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキップ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过"
           }
         }
       }

--- a/EPGPlayer/Localization/Localizable.xcstrings
+++ b/EPGPlayer/Localization/Localizable.xcstrings
@@ -151,6 +151,22 @@
         }
       }
     },
+    "Add reserve" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画予約"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加录制预约"
+          }
+        }
+      }
+    },
     "Add to calendar" : {
       "localizations" : {
         "ja" : {
@@ -326,6 +342,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        }
+      }
+    },
+    "Cancel reserve" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予約取消"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消录制预约"
           }
         }
       }
@@ -1149,6 +1181,9 @@
         }
       }
     },
+    "OK" : {
+
+    },
     "Open Settings" : {
       "localizations" : {
         "ja" : {
@@ -1386,6 +1421,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "汇报问题"
+          }
+        }
+      }
+    },
+    "Reserve error" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予約エラー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预约错误"
           }
         }
       }

--- a/EPGPlayer/Shared/Client/OpenAPI/openapi.yaml
+++ b/EPGPlayer/Shared/Client/OpenAPI/openapi.yaml
@@ -2304,27 +2304,28 @@ components:
       type: object
       allOf:
         - $ref: '#/components/schemas/EditManualReserveOption'
-      properties:
-        programId:
-          $ref: '#/components/schemas/ProgramId'
-        timeSpecifiedOption:
-          type: object
-          description: 時刻指定オプション
-          required:
-            - name
-            - channelId
-            - startAt
-            - endAt
+        - type: object
           properties:
-            name:
-              description: 番組名
-              type: string
-            channelId:
-              $ref: '#/components/schemas/ChannelId'
-            startAt:
-              $ref: '#/components/schemas/UnixtimeMS'
-            endAt:
-              $ref: '#/components/schemas/UnixtimeMS'
+            programId:
+              $ref: '#/components/schemas/ProgramId'
+            timeSpecifiedOption:
+              type: object
+              description: 時刻指定オプション
+              required:
+                - name
+                - channelId
+                - startAt
+                - endAt
+              properties:
+                name:
+                  description: 番組名
+                  type: string
+                channelId:
+                  $ref: '#/components/schemas/ChannelId'
+                startAt:
+                  $ref: '#/components/schemas/UnixtimeMS'
+                endAt:
+                  $ref: '#/components/schemas/UnixtimeMS'
     AddedReserve:
       description: 予約成功応答データ
       type: object

--- a/EPGPlayer/Shared/UI/EPG/EPGProgramView.swift
+++ b/EPGPlayer/Shared/UI/EPG/EPGProgramView.swift
@@ -15,16 +15,21 @@ struct EPGProgramView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
     @EnvironmentObject private var userSettings: UserSettings
-    
+
     let channel: Components.Schemas.ScheduleChannleItem
     let program: Components.Schemas.ScheduleProgramItem
-    
+
+    /// programId -> reserveId mapping, shared with EPGView
+    @Binding var reservedPrograms: [Int: Int]
+
     #if !os(tvOS)
     @Binding var notifier: EPGNotifier
     #endif
-    
+
     @State var showNotifyPermissionAlert = false
     @State var showEventEditView = false
+    @State var reserveInProgress = false
+    @State var reserveError: String? = nil
     #if os(iOS)
     @State var event: EKEvent? = nil
     @State var store = EKEventStore()
@@ -61,6 +66,8 @@ struct EPGProgramView: View {
                         Text(genreStr + " / " + subGenreStr)
                             .font(.subheadline)
                     }
+                    Divider()
+                    reserveSection
                     #if !os(tvOS)
                     Divider()
                     HStack {
@@ -218,6 +225,13 @@ struct EPGProgramView: View {
                     }
                 }
             }
+            .alert("Reserve error", isPresented: Binding(get: { reserveError != nil }, set: { if !$0 { reserveError = nil } })) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                if let reserveError {
+                    Text(verbatim: reserveError)
+                }
+            }
             .alert("Notification permission is disabled", isPresented: $showNotifyPermissionAlert) {
                 Button {
                     #if os(macOS)
@@ -238,6 +252,128 @@ struct EPGProgramView: View {
                EventEditView(event: $event, eventStore: store)
             }
             #endif
+        }
+    }
+}
+
+extension EPGProgramView {
+    var reserveSection: some View {
+        HStack {
+            Spacer()
+            if reserveInProgress {
+                ProgressView()
+            } else if let reserveId = reservedPrograms[program.id] {
+                Button(role: .destructive) {
+                    deleteReserve(reserveId: reserveId)
+                } label: {
+                    HStack(alignment: .center) {
+                        Image(systemName: "record.circle.fill")
+                            .font(.system(size: 25))
+                        Text("Cancel reserve")
+                    }
+                }
+                .tint(.red)
+                .buttonStyle(.borderless)
+            } else {
+                Button {
+                    addReserve()
+                } label: {
+                    HStack(alignment: .center) {
+                        Image(systemName: "record.circle")
+                            .font(.system(size: 25))
+                        Text("Add reserve")
+                    }
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.tint)
+            }
+            Spacer()
+        }
+    }
+
+    func addReserve() {
+        reserveInProgress = true
+        reserveError = nil
+        Task {
+            do {
+                let response = try await appState.client.api.postReserves(
+                    body: .json(.init(
+                        value1: .init(allowEndLack: true),
+                        value2: .init(programId: program.id)
+                    ))
+                )
+                switch response {
+                case .created(let created):
+                    let reserveId = try created.body.json.reserveId
+                    reservedPrograms[program.id] = reserveId
+                    Logger.info("Reserved program \(program.id) with reserveId \(reserveId)")
+                case .default(let statusCode, let error):
+                    let message = try error.body.json.message
+                    Logger.error("Failed to reserve program \(program.id): \(statusCode) \(message)")
+                    // Refresh reserves - the program may already be reserved by a rule
+                    await refreshReservedPrograms()
+                    if reservedPrograms[program.id] == nil {
+                        reserveError = message
+                    }
+                }
+            } catch {
+                reserveError = error.localizedDescription
+                Logger.error("Failed to reserve program \(program.id): \(error)")
+            }
+            reserveInProgress = false
+        }
+    }
+
+    func refreshReservedPrograms() async {
+        do {
+            var allReserves: [Components.Schemas.ReserveItem] = []
+            var offset = 0
+            let limit = 100
+            let maxPages = 50
+            for _ in 0..<maxPages {
+                let resp = try await appState.client.api.getReserves(
+                    query: .init(offset: offset, limit: limit, isHalfWidth: true)
+                ).ok.body.json
+                allReserves.append(contentsOf: resp.reserves)
+                if allReserves.count >= resp.total {
+                    break
+                }
+                offset += limit
+            }
+            var mapping: [Int: Int] = [:]
+            for reserve in allReserves {
+                if let programId = reserve.programId {
+                    mapping[programId] = reserve.id
+                }
+            }
+            reservedPrograms = mapping
+        } catch {
+            Logger.error("Failed to refresh reserves: \(error)")
+        }
+    }
+
+    func deleteReserve(reserveId: Int) {
+        reserveInProgress = true
+        reserveError = nil
+        Task {
+            do {
+                let response = try await appState.client.api.deleteReservesReserveId(
+                    path: .init(reserveId: reserveId)
+                )
+                switch response {
+                case .ok(_):
+                    reservedPrograms.removeValue(forKey: program.id)
+                    Logger.info("Deleted reserve \(reserveId) for program \(program.id)")
+                case .default(let statusCode, let error):
+                    let message = try error.body.json.message
+                    reserveError = message
+                    Logger.error("Failed to delete reserve \(reserveId): \(statusCode) \(message)")
+                }
+            } catch {
+                reserveError = error.localizedDescription
+                Logger.error("Failed to delete reserve \(reserveId): \(error)")
+            }
+            reserveInProgress = false
         }
     }
 }

--- a/EPGPlayer/Shared/UI/EPG/EPGView.swift
+++ b/EPGPlayer/Shared/UI/EPG/EPGView.swift
@@ -43,6 +43,9 @@ struct EPGView: View {
     @State var startHour: Int = -1
     @State var enableGenre: [Bool] = []
     
+    /// programId -> reserveId mapping for the current schedule range
+    @State var reservedPrograms: [Int: Int] = [:]
+
     #if !os(tvOS)
     @State var notifier = EPGNotifier()
     #endif
@@ -132,12 +135,12 @@ struct EPGView: View {
             #endif
             .sheet(item: $selectedProgram) { program in
                 #if !os(tvOS)
-                EPGProgramView(channel: program.channel, program: program.program, notifier: $notifier)
+                EPGProgramView(channel: program.channel, program: program.program, reservedPrograms: $reservedPrograms, notifier: $notifier)
                     #if os(macOS)
                     .presentationSizing(.page)
                     #endif
                 #else
-                EPGProgramView(channel: program.channel, program: program.program)
+                EPGProgramView(channel: program.channel, program: program.program, reservedPrograms: $reservedPrograms)
                 #endif
             }
             .sheet(isPresented: $showSettings) {
@@ -147,6 +150,9 @@ struct EPGView: View {
         .onAppear {
             if schedules.isEmpty {
                 refresh(manual: false)
+            }
+            Task {
+                await fetchReserves()
             }
             #if !os(tvOS)
             Task {
@@ -223,12 +229,23 @@ struct EPGView: View {
                                         .frame(minWidth: channelWidth - 2, idealWidth: channelWidth - 2, maxWidth: channelWidth - 2, minHeight: 0, idealHeight: heightOneDay / (24 * 3600 * 1000) * (programEndAt - programStartAt), maxHeight: .infinity, alignment: .topLeading)
                                     }
                                     .background {
+                                        let isReserved = reservedPrograms[program.id] != nil
                                         Color("Genre \(program.genre1 ?? 16)")
                                             #if !os(tvOS)
-                                            .border(notifier.setProgramIds.contains(String(program.id)) ? Color.red : Color.clear, width: 3)
+                                            .border(notifier.setProgramIds.contains(String(program.id)) ? Color.red : (isReserved ? Color.blue : Color.clear), width: 3)
+                                            #else
+                                            .border(isReserved ? Color.blue : Color.clear, width: 3)
                                             #endif
                                             .padding(.all, 1)
                                             .frame(width: channelWidth, height: heightOneDay / (24 * 3600 * 1000) * (programEndAt - programStartAt))
+                                    }
+                                    .overlay(alignment: .topTrailing) {
+                                        if reservedPrograms[program.id] != nil {
+                                            Image(systemName: "record.circle.fill")
+                                                .foregroundStyle(.red)
+                                                .font(.caption)
+                                                .padding(4)
+                                        }
                                     }
                                 }
                                 #if os(macOS) || os(tvOS)
@@ -430,6 +447,35 @@ struct EPGView: View {
                 Logger.error("Failed to load recordings: \(error)")
                 loadingState = .error(Text(verbatim: error.localizedDescription))
             }
+        }
+    }
+
+    func fetchReserves() async {
+        do {
+            var allReserves: [Components.Schemas.ReserveItem] = []
+            var offset = 0
+            let limit = 100
+            let maxPages = 50
+            for _ in 0..<maxPages {
+                let resp = try await appState.client.api.getReserves(
+                    query: .init(offset: offset, limit: limit, isHalfWidth: true)
+                ).ok.body.json
+                allReserves.append(contentsOf: resp.reserves)
+                if allReserves.count >= resp.total {
+                    break
+                }
+                offset += limit
+            }
+            var mapping: [Int: Int] = [:]
+            for reserve in allReserves {
+                if let programId = reserve.programId {
+                    mapping[programId] = reserve.id
+                }
+            }
+            reservedPrograms = mapping
+            Logger.info("Loaded \(mapping.count) reserved programs")
+        } catch {
+            Logger.error("Failed to load reserves: \(error)")
         }
     }
 }

--- a/EPGPlayer/Shared/UI/Recordings/RecordingDetailView.swift
+++ b/EPGPlayer/Shared/UI/Recordings/RecordingDetailView.swift
@@ -21,7 +21,12 @@ struct RecordingDetailView: View {
     #endif
     
     var item: RecordedItem
-    
+    var onDelete: (() -> Void)? = nil
+
+    @State private var showDeleteConfirmation = false
+    @State private var deleteInProgress = false
+    @State private var deleteError: String? = nil
+
     var body: some View {
         ScrollView(.vertical) {
             VStack(alignment: .center) {
@@ -142,6 +147,66 @@ struct RecordingDetailView: View {
             }
         }
         .navigationTitle(item.name)
+        .toolbar {
+            if onDelete != nil {
+                ToolbarItem(placement: .primaryAction) {
+                    if deleteInProgress {
+                        ProgressView()
+                    } else {
+                        Menu {
+                            Button(role: .destructive) {
+                                showDeleteConfirmation = true
+                            } label: {
+                                Label("Delete recording", systemImage: "trash")
+                            }
+                        } label: {
+                            Label("More", systemImage: "ellipsis")
+                        }
+                    }
+                }
+            }
+        }
+        .alert("Delete recording", isPresented: $showDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                deleteRecording()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(verbatim: item.name)
+        }
+        .alert("Delete error", isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            if let deleteError {
+                Text(verbatim: deleteError)
+            }
+        }
+    }
+
+    func deleteRecording() {
+        deleteInProgress = true
+        deleteError = nil
+        Task {
+            do {
+                let response = try await appState.client.api.deleteRecordedRecordedId(
+                    path: .init(recordedId: item.epgId)
+                )
+                switch response {
+                case .ok(_):
+                    Logger.info("Deleted recording \(item.epgId)")
+                    onDelete?()
+                    dismiss()
+                case .default(let statusCode, let error):
+                    let message = try error.body.json.message
+                    deleteError = message
+                    Logger.error("Failed to delete recording \(item.epgId): \(statusCode) \(message)")
+                }
+            } catch {
+                deleteError = error.localizedDescription
+                Logger.error("Failed to delete recording \(item.epgId): \(error)")
+            }
+            deleteInProgress = false
+        }
     }
 }
 

--- a/EPGPlayer/Shared/UI/Recordings/RecordingsView.swift
+++ b/EPGPlayer/Shared/UI/Recordings/RecordingsView.swift
@@ -15,6 +15,12 @@ struct RecordingsView: View {
     @Bindable var appState: AppState
     @Binding var activeTab: TabSelection
     
+    enum Segment: String, CaseIterable {
+        case recordings
+        case reserves
+    }
+
+    @State var selectedSegment: Segment = .recordings
     @State var showSearchView: Bool = false
     @State var searchQuery: SearchQuery? = nil
     
@@ -27,107 +33,130 @@ struct RecordingsView: View {
     
     var body: some View {
         NavigationStack {
-            ClientContentView(activeTab: $activeTab, loadingState: $loadingState, refresh: { waitTime in
-                refresh(waitTime: waitTime)
-            }, content: {
-                ScrollView {
-                    #if os(macOS)
-                    Spacer()
-                        .frame(height: 10)
-                    #endif
-                    
-                    if recorded.isEmpty {
-                        ContentUnavailableView("No recordings found", systemImage: "questionmark.circle")
-                    } else {
-                        #if os(tvOS)
-                        let gridItem = GridItem(.adaptive(minimum: 600), spacing: 15)
-                        #else
-                        let gridItem = GridItem(.adaptive(minimum: 300), spacing: 15)
-                        #endif
-                        LazyVGrid(columns: [gridItem], spacing: 15) {
-                            ForEach(recorded) { item in
-                                NavigationLink {
-                                    RecordingDetailView(item: item)
-                                } label: {
-                                    RecordingCell(item: item)
-                                }
-                                #if os(macOS) || os(tvOS)
-                                .buttonStyle(.borderless)
-                                #endif
-                                .tint(.primary)
-                                .id(item.id)
-                            }
-                            if case .loaded = loadingMoreState, recorded.count < totalCount {
-                                Spacer()
-                                    .onAppear {
-                                        loadMore()
-                                    }
-                            }
-                        }
-                        #if !os(tvOS)
-                        .padding(.horizontal)
-                        #endif
-                    }
-                    
-                    if recorded.count < totalCount {
-                        if case .loading = loadingMoreState {
-                            ProgressView()
-                                #if !os(tvOS)
-                                .controlSize(.large)
-                                #endif
-                        } else if case .error(let message) = loadingMoreState {
-                            ContentUnavailableView {
-                                Label("Error loading content", systemImage: "xmark.circle")
-                            } description: {
-                                message
-                            }
-                        }
-                    }
-                    
-                    #if os(macOS)
-                    Spacer()
-                        .frame(height: 10)
-                    #endif
+            Group {
+                switch selectedSegment {
+                case .recordings:
+                    recordingsContent
+                case .reserves:
+                    ReservesListView(activeTab: $activeTab)
                 }
-                .refreshable {
-                    refresh()
-                }
-            })
+            }
             .toolbar(content: {
+                ToolbarItem(placement: .principal) {
+                    Picker("Segment", selection: $selectedSegment) {
+                        Text("Recordings").tag(Segment.recordings)
+                        Text("Reserves").tag(Segment.reserves)
+                    }
+                    .pickerStyle(.segmented)
+                    .fixedSize()
+                }
                 #if os(macOS)
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        refresh()
-                    } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
+                if selectedSegment == .recordings {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            refresh()
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
                     }
                 }
                 #endif
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        showSearchView.toggle()
-                    } label: {
-                        Label("Search", systemImage: searchQuery == nil ? "magnifyingglass" : "sparkle.magnifyingglass")
+                if selectedSegment == .recordings {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            showSearchView.toggle()
+                        } label: {
+                            Label("Search", systemImage: searchQuery == nil ? "magnifyingglass" : "sparkle.magnifyingglass")
+                        }
                     }
                 }
             })
             #if !os(tvOS)
-            .navigationTitle("Recordings")
+            .navigationTitle(selectedSegment == .recordings ? "Recordings" : "Reserves")
             #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
             #endif
-        }
-        .onAppear {
-            if recorded.isEmpty {
-                refresh()
-            }
         }
         .sheet(isPresented: $showSearchView) {
             SearchView(searchQuery: $searchQuery, channels: channels.map { SearchChannel(name: $0.name, channelId: $0.id) })
         }
         .onChange(of: searchQuery, initial: true) { oldValue, newValue in
             if oldValue != newValue {
+                refresh()
+            }
+        }
+    }
+
+    var recordingsContent: some View {
+        ClientContentView(activeTab: $activeTab, loadingState: $loadingState, refresh: { waitTime in
+            refresh(waitTime: waitTime)
+        }, content: {
+            ScrollView {
+                #if os(macOS)
+                Spacer()
+                    .frame(height: 10)
+                #endif
+
+                if recorded.isEmpty {
+                    ContentUnavailableView("No recordings found", systemImage: "questionmark.circle")
+                } else {
+                    #if os(tvOS)
+                    let gridItem = GridItem(.adaptive(minimum: 600), spacing: 15)
+                    #else
+                    let gridItem = GridItem(.adaptive(minimum: 300), spacing: 15)
+                    #endif
+                    LazyVGrid(columns: [gridItem], spacing: 15) {
+                        ForEach(recorded) { item in
+                            NavigationLink {
+                                RecordingDetailView(item: item)
+                            } label: {
+                                RecordingCell(item: item)
+                            }
+                            #if os(macOS) || os(tvOS)
+                            .buttonStyle(.borderless)
+                            #endif
+                            .tint(.primary)
+                            .id(item.id)
+                        }
+                        if case .loaded = loadingMoreState, recorded.count < totalCount {
+                            Spacer()
+                                .onAppear {
+                                    loadMore()
+                                }
+                        }
+                    }
+                    #if !os(tvOS)
+                    .padding(.horizontal)
+                    #endif
+                }
+
+                if recorded.count < totalCount {
+                    if case .loading = loadingMoreState {
+                        ProgressView()
+                            #if !os(tvOS)
+                            .controlSize(.large)
+                            #endif
+                    } else if case .error(let message) = loadingMoreState {
+                        ContentUnavailableView {
+                            Label("Error loading content", systemImage: "xmark.circle")
+                        } description: {
+                            message
+                        }
+                    }
+                }
+
+                #if os(macOS)
+                Spacer()
+                    .frame(height: 10)
+                #endif
+            }
+            .refreshable {
+                refresh()
+            }
+        })
+        .onAppear {
+            if recorded.isEmpty {
                 refresh()
             }
         }

--- a/EPGPlayer/Shared/UI/Recordings/RecordingsView.swift
+++ b/EPGPlayer/Shared/UI/Recordings/RecordingsView.swift
@@ -109,7 +109,10 @@ struct RecordingsView: View {
                     LazyVGrid(columns: [gridItem], spacing: 15) {
                         ForEach(recorded) { item in
                             NavigationLink {
-                                RecordingDetailView(item: item)
+                                RecordingDetailView(item: item, onDelete: {
+                                    recorded.removeAll { $0.id == item.id }
+                                    totalCount -= 1
+                                })
                             } label: {
                                 RecordingCell(item: item)
                             }

--- a/EPGPlayer/Shared/UI/Recordings/ReservesListView.swift
+++ b/EPGPlayer/Shared/UI/Recordings/ReservesListView.swift
@@ -1,0 +1,209 @@
+//
+//  ReservesListView.swift
+//  EPGPlayer
+//
+//  Created by Yi Xie on 2025/07/02.
+//
+//  SPDX-License-Identifier: MPL-2.0
+
+import SwiftUI
+
+struct ReservesListView: View {
+    @Environment(AppState.self) private var appState
+    @Binding var activeTab: TabSelection
+
+    @State var loadingState = LoadingState.loading
+    @State var reserves: [Components.Schemas.ReserveItem] = []
+    @State var deleteError: String? = nil
+
+    var body: some View {
+        ClientContentView(activeTab: $activeTab, loadingState: $loadingState, refresh: { waitTime in
+            refresh(waitTime: waitTime)
+        }, content: {
+            ScrollView {
+                #if os(macOS)
+                Spacer()
+                    .frame(height: 10)
+                #endif
+
+                if reserves.isEmpty {
+                    ContentUnavailableView("No reserves found", systemImage: "questionmark.circle")
+                } else {
+                    LazyVStack(spacing: 12) {
+                        ForEach(reserves, id: \.id) { reserve in
+                            ReserveCell(reserve: reserve, onDelete: {
+                                deleteReserve(reserveId: reserve.id)
+                            })
+                        }
+                    }
+                    #if !os(tvOS)
+                    .padding(.horizontal)
+                    #endif
+                }
+
+                #if os(macOS)
+                Spacer()
+                    .frame(height: 10)
+                #endif
+            }
+            .refreshable {
+                refresh()
+            }
+        })
+        .alert("Reserve error", isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            if let deleteError {
+                Text(verbatim: deleteError)
+            }
+        }
+        .onAppear {
+            if reserves.isEmpty {
+                refresh()
+            }
+        }
+    }
+
+    func refresh(waitTime: Duration = .zero) {
+        reserves = []
+        loadingState = .loading
+        Task {
+            do {
+                try await Task.sleep(for: waitTime)
+
+                // Ensure channelMap is populated for channel name display
+                if Components.Schemas.RecordedItem.channelMap.isEmpty {
+                    let channels = try await appState.client.api.getChannels().ok.body.json
+                    Components.Schemas.RecordedItem.channelMap = channels.reduce(into: [Int: Components.Schemas.ChannelItem]()) { map, item in
+                        map[item.id] = item
+                    }
+                }
+
+                var allReserves: [Components.Schemas.ReserveItem] = []
+                var offset = 0
+                let limit = 100
+                let maxPages = 50
+                for _ in 0..<maxPages {
+                    let resp = try await appState.client.api.getReserves(
+                        query: .init(offset: offset, limit: limit, isHalfWidth: true)
+                    ).ok.body.json
+                    allReserves.append(contentsOf: resp.reserves)
+                    if allReserves.count >= resp.total {
+                        break
+                    }
+                    offset += limit
+                }
+                reserves = allReserves.sorted { $0.startAt < $1.startAt }
+                loadingState = .loaded
+                Logger.info("Loaded \(reserves.count) reserves")
+            } catch {
+                Logger.error("Failed to load reserves: \(error)")
+                loadingState = .error(Text(verbatim: error.localizedDescription))
+            }
+        }
+    }
+
+    func deleteReserve(reserveId: Int) {
+        Task {
+            do {
+                let response = try await appState.client.api.deleteReservesReserveId(
+                    path: .init(reserveId: reserveId)
+                )
+                switch response {
+                case .ok(_):
+                    reserves.removeAll { $0.id == reserveId }
+                    Logger.info("Deleted reserve \(reserveId)")
+                case .default(let statusCode, let error):
+                    let message = try error.body.json.message
+                    deleteError = message
+                    Logger.error("Failed to delete reserve \(reserveId): \(statusCode) \(message)")
+                }
+            } catch {
+                deleteError = error.localizedDescription
+                Logger.error("Failed to delete reserve \(reserveId): \(error)")
+            }
+        }
+    }
+}
+
+struct ReserveCell: View {
+    let reserve: Components.Schemas.ReserveItem
+    let onDelete: () -> Void
+
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        let startAt = Date(timeIntervalSince1970: TimeInterval(reserve.startAt / 1000))
+        let endAt = Date(timeIntervalSince1970: TimeInterval(reserve.endAt / 1000))
+        let durationMinutes = (reserve.endAt - reserve.startAt) / 60 / 1000
+
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: reserve.name)
+                    .font(.headline)
+                    .lineLimit(2)
+                Text(verbatim: channelName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: startAt.formatted(RecordingCell.startDateFormatStyle)
+                     + " ~ "
+                     + endAt.formatted(RecordingCell.endDateFormatStyle)
+                     + " (\(durationMinutes)分)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let description = reserve.description {
+                    Text(verbatim: description)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                HStack(spacing: 8) {
+                    if reserve.isConflict {
+                        Label("Conflict", systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.red)
+                    }
+                    if reserve.isOverlap {
+                        Label("Overlap", systemImage: "exclamationmark.triangle")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+                    if reserve.isSkip {
+                        Label("Skip", systemImage: "forward.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if reserve.ruleId != nil {
+                        Label("Rule", systemImage: "gearshape")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Button(role: .destructive) {
+                showDeleteConfirmation = true
+            } label: {
+                Image(systemName: "trash")
+                    .font(.title3)
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.background)
+                .shadow(radius: 2)
+        }
+        .alert("Cancel reserve", isPresented: $showDeleteConfirmation) {
+            Button("Cancel reserve", role: .destructive, action: onDelete)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(verbatim: reserve.name)
+        }
+    }
+
+    var channelName: String {
+        Components.Schemas.RecordedItem.channelMap[reserve.channelId]?.name ?? "\(reserve.channelId)"
+    }
+}


### PR DESCRIPTION
Hi! First of all, thank you so much for developing EPGPlayer. I've been using it daily to watch and manage
   my recordings, and it's been an incredibly useful app for interacting with EPGStation.

  While using the app, I found myself frequently switching to the EPGStation web UI just to manage recording
   reservations. So I decided to implement this functionality directly in EPGPlayer. Here's a summary of the
   changes:

  Summary

  1. Manual recording reservation from EPG program view

  - Add/cancel recording reservations directly from the EPG program detail sheet
  - Visual indicators on the EPG grid: blue border and red record icon for reserved programs
  - Reserves are fetched on every EPG tab appearance for up-to-date status
  - Handles duplicate reservations gracefully (e.g., programs already reserved by auto-rules)

  2. Reserves list view

  - Added a segmented control (Recordings / Reserves) to the existing Recordings tab, keeping the tab count
  at 5 per HIG guidelines
  - Reserves list displays program name, channel, air time, and status badges (conflict, overlap, skip,
  rule-based)
  - Supports deleting reserves with a confirmation dialog

  3. Recording deletion

  - Added an ellipsis menu in the recording detail view with a delete option
  - Confirmation dialog before deletion to prevent accidental data loss

  Other notes

  - Fixed the ManualReserveOption OpenAPI schema (allOf with sibling properties was ignored by Swift OpenAPI
   Generator)
  - All new strings are localized in Japanese and Simplified Chinese
  - Builds successfully on iOS and macOS (tvOS not tested due to SDK availability, but platform conditionals
   are handled)

  Test plan

  - Add a recording reservation from the EPG program view
  - Verify reserved programs are visually indicated on the EPG grid
  - Cancel a reservation from the EPG program view
  - View the reserves list via the segmented control in the Recordings tab
  - Delete a reservation from the reserves list
  - Delete a recording from the recording detail view
  - Verify error handling when the server returns an error

  I hope this is useful! Happy to adjust anything based on your feedback.